### PR TITLE
Remove reboot on exit (also done by CRT)

### DIFF
--- a/main.c
+++ b/main.c
@@ -39,5 +39,4 @@ void main(void)
 
     pb_show_debug_screen();
     pb_kill();
-    HalReturnToFirmware(ReturnFirmwareQuickReboot);
 }


### PR DESCRIPTION
I've still had this locally.
Otherwise, the current master can not be compiled with the latest nxdk master (which renamed `ReturnFirmwareQuickReboot`).